### PR TITLE
WFUI-109 Make it clearer which datasheet attribute an open tree picker relates to.

### DIFF
--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -697,7 +697,7 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
                     }
                 }
 
-                angular.element( checkBoxLayer.previousSibling ).removeClass( 'buttonClicked' );
+                angular.element( checkBoxLayer.parentElement ).removeClass('buttonClicked');
                 angular.element( checkBoxLayer ).removeClass( 'show' );
                 angular.element( document ).off( 'click', $scope.externalClickListener );
                 angular.element( document ).off( 'keydown', $scope.keyboardListener );


### PR DESCRIPTION
Make sure multi-select knows it's closed after clicking away.

The "buttonClicked" element is the parent not the sibling.